### PR TITLE
feat: add mycryptotaxcalculator select option

### DIFF
--- a/history.html
+++ b/history.html
@@ -389,6 +389,7 @@
                       <option value="2">Bitcoin.tax (CSV)</option>
                       <option value="3">Cointracking.info (CSV)</option>
                       <option value="4">Cointracking.info (CustomExchange)</option>
+                      <option value="1">myCryptoTaxCalculator.com (CSV)</option>
                     </select>
                   </div>
                   <div id="exportFunds" class="col-md-6 noPad" style="overflow:hidden;">


### PR DESCRIPTION
minimal changes required because using same csv download format as default V2. Looking at history.js there shouldn't be a conflict when using the same value.