### PR TITLE
Add CryptoTax.io to trade and funds history export

### DIFF
--- a/history.html
+++ b/history.html
@@ -399,6 +399,7 @@
                       <option value="4">Cointracking.info (CustomExchange)</option>
 					  <option value="5">TokenTax (CSV)</option>
                       <option value="1">myCryptoTaxCalculator.com (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                   <div id="exportFunds" class="col-md-6 noPad" style="overflow:hidden;">
@@ -411,6 +412,7 @@
                       <option value="0" disabled selected>Select export format</option>
                       <option value="1">Default(CSV)</option>
                       <option value="2">Cointracking.info (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                 </div>

--- a/history.js
+++ b/history.js
@@ -1837,15 +1837,6 @@ var isAddressPage = true;
 					buyToken = allTrades[i]['Base'].name;
 				}
 
-				if (feeAmount && feeToken) {
-					// apply CryptoTax fee rules
-					if (feeToken === buyToken) {
-						buyAmount = buyAmount + feeAmount;
-					} else if (feeToken === sellToken) {
-						sellAmount = sellAmount - feeAmount;
-					}
-				}
-
 				row = [
 					exchange, exchange, transactionDate,
 					buyToken, sellToken, buyAmount, sellAmount, allTrades[i]['Hash'],

--- a/history10.html
+++ b/history10.html
@@ -391,6 +391,7 @@
                       <option value="4">Cointracking.info (CustomExchange)</option>
 					  <option value="5">TokenTax (CSV)</option>
                       <option value="1">myCryptoTaxCalculator.com (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                   <div id="exportFunds" class="col-md-6 noPad hidden" style="overflow:hidden;">
@@ -403,6 +404,7 @@
                       <option value="0" disabled selected>Select export format</option>
                       <option value="1">Default(CSV)</option>
                       <option value="2">Cointracking.info (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                 </div>

--- a/history2.html
+++ b/history2.html
@@ -394,6 +394,7 @@
                       <option value="4">Cointracking.info (CustomExchange)</option>
 					  <option value="5">TokenTax (CSV)</option>
                       <option value="1">myCryptoTaxCalculator.com (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                   <div id="exportFunds" class="col-md-6 noPad" style="overflow:hidden;">
@@ -406,6 +407,7 @@
                       <option value="0" disabled selected>Select export format</option>
                       <option value="1">Default(CSV)</option>
                       <option value="2">Cointracking.info (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                 </div>

--- a/history3.html
+++ b/history3.html
@@ -386,6 +386,7 @@
                       <option value="4">Cointracking.info (CustomExchange)</option>
 					  <option value="5">TokenTax (CSV)</option>
                       <option value="1">myCryptoTaxCalculator.com (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                   <div id="exportFunds" class="col-md-6 noPad" style="overflow:hidden;">
@@ -398,6 +399,7 @@
                       <option value="0" disabled selected>Select export format</option>
                       <option value="1">Default(CSV)</option>
                       <option value="2">Cointracking.info (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                 </div>

--- a/history4.html
+++ b/history4.html
@@ -397,6 +397,7 @@
                       <option value="4">Cointracking.info (CustomExchange)</option>
 					  <option value="5">TokenTax (CSV)</option>
                       <option value="1">myCryptoTaxCalculator.com (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                   <div id="exportFunds" class="hidden col-md-6 noPad" style="overflow:hidden;">
@@ -409,6 +410,7 @@
                       <option value="0" disabled selected>Select export format</option>
                       <option value="1">Default(CSV)</option>
                       <option value="2">Cointracking.info (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                 </div>

--- a/history5.html
+++ b/history5.html
@@ -391,6 +391,7 @@
                       <option value="4">Cointracking.info (CustomExchange)</option>
 					  <option value="5">TokenTax (CSV)</option>
                       <option value="1">myCryptoTaxCalculator.com (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                   <div id="exportFunds" class="hidden col-md-6 noPad" style="overflow:hidden;">
@@ -403,6 +404,7 @@
                       <option value="0" disabled selected>Select export format</option>
                       <option value="1">Default(CSV)</option>
                       <option value="2">Cointracking.info (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                 </div>

--- a/history6.html
+++ b/history6.html
@@ -392,6 +392,7 @@
                       <option value="4">Cointracking.info (CustomExchange)</option>
 					  <option value="5">TokenTax (CSV)</option>
                       <option value="1">myCryptoTaxCalculator.com (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                   <div id="exportFunds" class="hidden col-md-6 noPad" style="overflow:hidden;">
@@ -404,6 +405,7 @@
                       <option value="0" disabled selected>Select export format</option>
                       <option value="1">Default(CSV)</option>
                       <option value="2">Cointracking.info (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                 </div>

--- a/history7.html
+++ b/history7.html
@@ -401,6 +401,7 @@
                       <option value="4">Cointracking.info (CustomExchange)</option>
 					  <option value="5">TokenTax (CSV)</option>
                       <option value="1">myCryptoTaxCalculator.com (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                   <div id="exportFunds" class="hidden col-md-6 noPad" style="overflow:hidden;">
@@ -413,6 +414,7 @@
                       <option value="0" disabled selected>Select export format</option>
                       <option value="1">Default(CSV)</option>
                       <option value="2">Cointracking.info (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                 </div>

--- a/history8.html
+++ b/history8.html
@@ -391,6 +391,7 @@
                       <option value="4">Cointracking.info (CustomExchange)</option>
 					  <option value="5">TokenTax (CSV)</option>
                       <option value="1">myCryptoTaxCalculator.com (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                   <div id="exportFunds" class="col-md-6 noPad" style="overflow:hidden;">
@@ -403,6 +404,7 @@
                       <option value="0" disabled selected>Select export format</option>
                       <option value="1">Default(CSV)</option>
                       <option value="2">Cointracking.info (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                 </div>

--- a/history9.html
+++ b/history9.html
@@ -391,6 +391,7 @@
                       <option value="4">Cointracking.info (CustomExchange)</option>
 					  <option value="5">TokenTax (CSV)</option>
                       <option value="1">myCryptoTaxCalculator.com (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                   <div id="exportFunds" class="col-md-6 noPad" style="overflow:hidden;">
@@ -403,6 +404,7 @@
                       <option value="0" disabled selected>Select export format</option>
                       <option value="1">Default(CSV)</option>
                       <option value="2">Cointracking.info (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                 </div>

--- a/trades.html
+++ b/trades.html
@@ -418,6 +418,7 @@
                       <option value="4">Cointracking.info (CustomExchange)</option>
 					  <option value="5">TokenTax (CSV)</option>
                       <option value="1">myCryptoTaxCalculator.com (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                   <div id="exportFunds" class="hidden col-md-6 noPad" style="overflow:hidden;">
@@ -430,6 +431,7 @@
                       <option value="0" disabled selected>Select export format</option>
                       <option value="1">Default(CSV)</option>
                       <option value="2">Cointracking.info (CSV)</option>
+                      <option value="6">CryptoTax.io (CSV)</option>
                     </select>
                   </div>
                 </div>


### PR DESCRIPTION
I added export options for CryptoTax.io CSV format, for trade history as well as funds history.

In particular, I added select options with value `6` on all pages and extended the export functionality in `generateTradesData()` and `generateFundsData()`.